### PR TITLE
Decouple texture loading from main thread by adding a page list. This…

### DIFF
--- a/lib/gl/renderer/IDevice.hpp
+++ b/lib/gl/renderer/IDevice.hpp
@@ -39,7 +39,8 @@ public:
     ///
     /// @param data The data to write.
     /// @param addr The address to write to.
-    virtual void writeToDeviceMemory(tcb::span<const uint8_t> data, const uint32_t addr) = 0;
+    /// @return True if the write operation was successful, false otherwise.
+    virtual bool writeToDeviceMemory(tcb::span<const uint8_t> data, const uint32_t addr) = 0;
 
     /// @brief Waits until the device is idle and ready for new commands.
     ///     When this method returns, the buffer used in streamDisplayList can be safely reused.

--- a/lib/gl/renderer/Renderer.cpp
+++ b/lib/gl/renderer/Renderer.cpp
@@ -246,8 +246,7 @@ void Renderer::uploadTextures()
     m_textureManager.uploadTextures(
         [&](uint32_t gramAddr, const tcb::span<const uint8_t> data)
         {
-            m_device.writeToDeviceMemory(data, gramAddr);
-            return true;
+            return m_device.writeToDeviceMemory(data, gramAddr);
         });
 }
 

--- a/lib/gl/renderer/dse/DmaStreamEngine.hpp
+++ b/lib/gl/renderer/dse/DmaStreamEngine.hpp
@@ -38,18 +38,21 @@ public:
 
     void streamDisplayList(const uint8_t index, uint32_t size) override
     {
+        blockUntilDeviceIsIdle();
         size = fillWhenDataIsTooSmall(index, size);
         const uint32_t commandSize = addDseStreamCommand(index, size);
         m_busConnector.writeData(index, size + commandSize);
     }
 
-    void writeToDeviceMemory(tcb::span<const uint8_t> data, const uint32_t addr) override
+    bool writeToDeviceMemory(tcb::span<const uint8_t> data, const uint32_t addr) override
     {
+        blockUntilDeviceIsIdle();
         const uint32_t commandSize = addDseStoreCommand(
             (std::max)(static_cast<uint32_t>(data.size()), DEVICE_MIN_TRANSFER_SIZE),
             addr + RenderConfig::GRAM_MEMORY_LOC);
         addDseStorePayload(commandSize, data);
         m_busConnector.writeData(getStoreBufferIndex(), commandSize + data.size());
+        return true;
     }
 
     void blockUntilDeviceIsIdle() override

--- a/lib/gl/renderer/threadedRasterizer/DeviceUploadList.hpp
+++ b/lib/gl/renderer/threadedRasterizer/DeviceUploadList.hpp
@@ -1,3 +1,20 @@
+// RasterIX
+// https://github.com/ToNi3141/RasterIX
+// Copyright (c) 2025 ToNi3141
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 #ifndef DEVICE_UPLOAD_LIST_HPP
 #define DEVICE_UPLOAD_LIST_HPP
 

--- a/lib/gl/renderer/threadedRasterizer/DeviceUploadList.hpp
+++ b/lib/gl/renderer/threadedRasterizer/DeviceUploadList.hpp
@@ -1,0 +1,78 @@
+#ifndef DEVICE_UPLOAD_LIST_HPP
+#define DEVICE_UPLOAD_LIST_HPP
+
+#include "renderer/displaylist/DisplayList.hpp"
+#include <array>
+#include <cstdint>
+#include <spdlog/spdlog.h>
+#include <tcb/span.hpp>
+
+namespace rr
+{
+
+template <std::size_t BUFFER_SIZE, std::size_t PAGE_SIZE>
+class DeviceUploadList
+{
+public:
+    struct Page
+    {
+        uint32_t addr;
+        uint8_t data[PAGE_SIZE];
+    };
+
+    DeviceUploadList()
+    {
+        m_pageList.setBuffer(tcb::span<uint8_t>(m_buffer.data(), m_buffer.size()));
+    }
+
+    bool addPage(tcb::span<const uint8_t> pageData, uint32_t addr)
+    {
+        if (pageData.size() > PAGE_SIZE)
+        {
+            SPDLOG_ERROR("Page data size exceeds PAGE_SIZE limit");
+            return false;
+        }
+
+        Page* page = m_pageList.create<Page>();
+        if (page)
+        {
+            page->addr = addr;
+            std::copy(pageData.begin(), pageData.end(), page->data);
+            return true;
+        }
+        SPDLOG_ERROR("Failed to allocate page in display list");
+        return false;
+    }
+
+    const Page* getNextPage()
+    {
+        if (m_pageList.atEnd() == false)
+        {
+            return m_pageList.getNext<Page>();
+        }
+        return nullptr;
+    }
+
+    bool atEnd() const
+    {
+        return m_pageList.atEnd();
+    }
+
+    bool empty() const
+    {
+        return m_pageList.getSize() == 0;
+    }
+
+    void clear()
+    {
+        m_pageList.resetGet();
+        m_pageList.clear();
+    }
+
+private:
+    displaylist::DisplayList m_pageList {};
+    std::array<uint8_t, BUFFER_SIZE> m_buffer {};
+};
+
+} // namespace rr
+#endif // DEVICE_UPLOAD_LIST_HPP


### PR DESCRIPTION
… list is loaded before the new transformed display list is rendered and does not anymore blocks the main thread to upload texture data.